### PR TITLE
clean header.frame_id for ROS 2 compatibility

### DIFF
--- a/packages/tof_driver/tof_driver/tof_driver_node.py
+++ b/packages/tof_driver/tof_driver/tof_driver_node.py
@@ -17,8 +17,8 @@ OUT_OF_RANGE = 999
 
 class ToFNode(ROS2Node):
     def __init__(self):
-        super().__init__('tof_node')
         self._robot_name = get_robot_name()
+        super().__init__('tof_node', namespace=f"/{self._robot_name}")
         # arguments
         self.declare_parameter("sensor_name", "front_center")
         self._sensor_name = self.get_parameter("sensor_name").get_parameter_value().string_value
@@ -57,7 +57,17 @@ class ToFNode(ROS2Node):
         tof_msg = ROSRange()
         tof_msg.header = Header()
         tof_msg.header.stamp = self.get_clock().now().to_msg()
-        tof_msg.header.frame_id = tof.header.frame
+        frame_id = getattr(tof.header, "frame", None)
+        if isinstance(frame_id, bytes):
+            try:
+                frame_id = frame_id.decode("utf-8", errors="ignore")
+            except Exception:
+                frame_id = ""
+        elif frame_id is None:
+            frame_id = ""
+        elif not isinstance(frame_id, str):
+            frame_id = str(frame_id)
+        tof_msg.header.frame_id = frame_id
         tof_msg.max_range = float(MAX_RANGE)
         tof_msg.range = float(distance)  # Ensure distance is float
         tof_msg.variance = 0.0


### PR DESCRIPTION
Testing:
MATRIX
```
dts matrix run --standalone --embedded --map sandbox --verbose
dts matrix attach --engine ${IP_ADDRESS} ${VEHICLE} map_0/vehicle_0
```

BUILD in dt-ros2-interface repo
```
dt-ros2-interface$ dts devel build -H ${VEHICLE}
dts stack up -H ${VEHICLE} ros2/duckiebot
```

TEST
```
ssh duckie@{vehicle}.local
docker exec -it ros2-tof bash

ros2 topic echo /${VEHICLE}/range
```

Move vehicle in matrix to ensure range value changes.

```
header:
  stamp:
    sec: 1758498279
    nanosec: 82089263
  frame_id: ''
radiation_type: 0
field_of_view: 0.0
min_range: 0.0
max_range: 99.0
range: 0.24090860784053802
variance: 0.0
---

```