### PR TITLE
DTSW-7882 fix: connect MAVROS to the PX4 serial port on real robots

### DIFF
--- a/launchers/mavros.sh
+++ b/launchers/mavros.sh
@@ -13,7 +13,17 @@ source /environment.sh
 # setpoint_attitude plugin and sets setpoint_raw.thrust_scaling=1.0.
 # Without it, MAVROS uses its built-in defaults and the current
 # PoseStamped+thrust OFFBOARD control path is not consumed.
-FCU_URL=${FCU_URL:-"udp://:14540@"}
+#
+# Select the MAVLink endpoint based on the robot hardware:
+#   - virtual robots: PX4 SITL exposes MAVLink over UDP on port 14540
+#   - real robots:    the PX4 flight controller is connected over USB (CDC-ACM),
+#                     enumerating as /dev/ttyACM0 (baud is nominal for CDC-ACM)
+# An explicit FCU_URL environment variable always takes precedence.
+if [ "${ROBOT_HARDWARE}" == "virtual" ]; then
+  FCU_URL=${FCU_URL:-"udp://:14540@"}
+else
+  FCU_URL=${FCU_URL:-"serial:///dev/ttyACM0:57600"}
+fi
 MAVROS_CONFIG=${MAVROS_CONFIG:-"${DT_PROJECT_PATH}/assets/mavros/px4_config.yaml"}
 dt-exec ros2 run mavros mavros_node --ros-args \
     -p "fcu_url:=${FCU_URL}" \


### PR DESCRIPTION
## Problem

On a real Duckiedrone (DD24), MAVROS never connects to the PX4 flight controller — `/mavros/state` stays `connected: false`, so arming and OFFBOARD control are impossible.

The launcher defaulted the MAVLink endpoint to the **PX4 SITL** companion port for *every* robot:

```bash
FCU_URL=${FCU_URL:-"udp://:14540@"}
```

`udp://:14540@` is only valid for SITL. On real hardware the PX4 FC is connected over **USB (CDC-ACM)** → `/dev/ttyACM0`, so nothing ever publishes to UDP 14540 and MAVROS waits forever (logs repeat `VER: ... request timeout` / `your FCU don't support AUTOPILOT_VERSION`).

## Fix

Select the default `FCU_URL` based on `ROBOT_HARDWARE`, mirroring the existing `mavlink-proxy.sh` switch in `dt-duckiebot-interface`:

- **virtual** → `udp://:14540@` (PX4 SITL)
- **real** → `serial:///dev/ttyACM0:57600` (PX4 over USB; baud is nominal for CDC-ACM)

An explicit `FCU_URL` env var still takes precedence, so the stack can override it without touching the launcher.

## Testing

- Reviewed `mavlink-proxy.sh` for the established `ROBOT_HARDWARE == "virtual"` convention.
- Verified on a real DD24 (`robot_hardware=raspberry_pi_64`) that the previous default left `/mavros/state` `connected: false` with `mavros_node` bound to UDP 14540 and no peer.
- Live serial connection verification on hardware is pending FC USB enumeration (separate from this launcher change).

## Notes

Related but out of scope: `dt-px4:ente` is published amd64-only (no `-${ARCH}` suffix) and crash-loops on arm64; it also runs unconditionally on real robots. Tracked separately.

Jira: https://ethidsc.atlassian.net/browse/DTSW-7882

🤖 Generated with [Claude Code](https://claude.com/claude-code)