### PR TITLE
Load MAVROS PX4 config for OFFBOARD attitude control

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,6 +171,9 @@ RUN dt-install-launchers "${PROJECT_LAUNCHERS_PATH}"
 COPY ./assets/entrypoint.d "${PROJECT_PATH}/assets/entrypoint.d"
 COPY ./assets/environment.d "${PROJECT_PATH}/assets/environment.d"
 
+# mavros plugin configuration (loaded by launchers/mavros.sh)
+COPY ./assets/mavros "${PROJECT_PATH}/assets/mavros"
+
 # define default command
 CMD ["bash", "-c", "dt-launcher-${DT_LAUNCHER}"]
 

--- a/assets/mavros/px4_config.yaml
+++ b/assets/mavros/px4_config.yaml
@@ -1,16 +1,17 @@
 # MAVROS plugin parameter overrides for the Duckiedrone (PX4).
 #
 # Loaded by launchers/mavros.sh via `--params-file`. Without this, mavros runs
-# on built-in defaults and `setpoint_attitude.use_quaternion` is false, which
-# means the `/mavros/setpoint_attitude/attitude` (PoseStamped) topic is never
-# created — so attitude+thrust OFFBOARD control (the altitude PID) cannot work.
+# on built-in defaults. In that mode, `setpoint_attitude.use_quaternion` is
+# false, so the setpoint_attitude plugin consumes `cmd_vel` rather than the
+# `attitude` PoseStamped interface used by the current attitude+thrust
+# OFFBOARD controller.
 #
 # The `/**/` glob applies these to the mavros plugin component nodes
 # (e.g. /mavros/setpoint_attitude).
 
 /**/setpoint_attitude:
   ros__parameters:
-    use_quaternion: true        # expose /mavros/setpoint_attitude/attitude (PoseStamped)
+    use_quaternion: true        # consume PoseStamped attitude setpoints instead of cmd_vel
 
 /**/setpoint_raw:
   ros__parameters:

--- a/assets/mavros/px4_config.yaml
+++ b/assets/mavros/px4_config.yaml
@@ -1,0 +1,17 @@
+# MAVROS plugin parameter overrides for the Duckiedrone (PX4).
+#
+# Loaded by launchers/mavros.sh via `--params-file`. Without this, mavros runs
+# on built-in defaults and `setpoint_attitude.use_quaternion` is false, which
+# means the `/mavros/setpoint_attitude/attitude` (PoseStamped) topic is never
+# created — so attitude+thrust OFFBOARD control (the altitude PID) cannot work.
+#
+# The `/**/` glob applies these to the mavros plugin component nodes
+# (e.g. /mavros/setpoint_attitude).
+
+/**/setpoint_attitude:
+  ros__parameters:
+    use_quaternion: true        # expose /mavros/setpoint_attitude/attitude (PoseStamped)
+
+/**/setpoint_raw:
+  ros__parameters:
+    thrust_scaling: 1.0         # PX4 expects normalized [0,1] thrust (no scaling)

--- a/launchers/mavros.sh
+++ b/launchers/mavros.sh
@@ -9,10 +9,10 @@ source /environment.sh
 # NOTE: Use `dt-exec COMMAND` to run the main process (blocking process)
 
 # Launch MAVROS
-# The params file enables setpoint_attitude.use_quaternion (so the
-# /mavros/setpoint_attitude/attitude PoseStamped topic exists) and sets
-# setpoint_raw.thrust_scaling=1.0. Without it, attitude+thrust OFFBOARD
-# control (the altitude PID) cannot work.
+# The params file enables quaternion attitude setpoints for the MAVROS
+# setpoint_attitude plugin and sets setpoint_raw.thrust_scaling=1.0.
+# Without it, MAVROS uses its built-in defaults and the current
+# PoseStamped+thrust OFFBOARD control path is not consumed.
 FCU_URL=${FCU_URL:-"udp://:14540@"}
 MAVROS_CONFIG=${MAVROS_CONFIG:-"${DT_PROJECT_PATH}/assets/mavros/px4_config.yaml"}
 dt-exec ros2 run mavros mavros_node --ros-args \

--- a/launchers/mavros.sh
+++ b/launchers/mavros.sh
@@ -16,8 +16,8 @@ source /environment.sh
 FCU_URL=${FCU_URL:-"udp://:14540@"}
 MAVROS_CONFIG=${MAVROS_CONFIG:-"${DT_PROJECT_PATH}/assets/mavros/px4_config.yaml"}
 dt-exec ros2 run mavros mavros_node --ros-args \
-    -p fcu_url:=${FCU_URL} \
-    --params-file ${MAVROS_CONFIG}
+    -p "fcu_url:=${FCU_URL}" \
+    --params-file "${MAVROS_CONFIG}"
 
 # wait for app to end
 dt-launchfile-join

--- a/launchers/mavros.sh
+++ b/launchers/mavros.sh
@@ -9,8 +9,15 @@ source /environment.sh
 # NOTE: Use `dt-exec COMMAND` to run the main process (blocking process)
 
 # Launch MAVROS
+# The params file enables setpoint_attitude.use_quaternion (so the
+# /mavros/setpoint_attitude/attitude PoseStamped topic exists) and sets
+# setpoint_raw.thrust_scaling=1.0. Without it, attitude+thrust OFFBOARD
+# control (the altitude PID) cannot work.
 FCU_URL=${FCU_URL:-"udp://:14540@"}
-dt-exec ros2 run mavros mavros_node --ros-args -p fcu_url:=${FCU_URL}
+MAVROS_CONFIG=${MAVROS_CONFIG:-"${DT_PROJECT_PATH}/assets/mavros/px4_config.yaml"}
+dt-exec ros2 run mavros mavros_node --ros-args \
+    -p fcu_url:=${FCU_URL} \
+    --params-file ${MAVROS_CONFIG}
 
 # wait for app to end
 dt-launchfile-join


### PR DESCRIPTION
mavros_node was launched with defaults only, so
setpoint_attitude.use_quaternion was false and the /mavros/setpoint_attitude/attitude (PoseStamped) topic was never created — breaking attitude+thrust OFFBOARD control used by the altitude PID.

Add assets/mavros/px4_config.yaml enabling use_quaternion and setting setpoint_raw.thrust_scaling=1.0, load it in launchers/mavros.sh via --params-file (overridable with MAVROS_CONFIG), and COPY the assets/mavros directory into the image.

DTSW-7911