### PR TITLE
DTSW-7973-Add-Duckiematrix-interface

### DIFF
--- a/launchers/duckiematrix-interface.sh
+++ b/launchers/duckiematrix-interface.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+source /environment.sh
+
+# YOUR CODE BELOW THIS LINE
+# ----------------------------------------------------------------------------
+
+
+# NOTE: Use the variable DT_PROJECT_PATH to know the absolute path to your code
+# NOTE: Use `dt-exec COMMAND` to run the main process (blocking process)
+
+# Launch the Duckiematrix interface node using launch file
+dt-exec ros2 launch duckiematrix_interface duckiematrix_interface.launch.py robot_name:=$VEHICLE_NAME
+
+# Wait for app to end
+dt-launchfile-join
+
+# ----------------------------------------------------------------------------
+# YOUR CODE ABOVE THIS LINE

--- a/packages/duckiematrix_interface/duckiematrix_interface/__init__.py
+++ b/packages/duckiematrix_interface/duckiematrix_interface/__init__.py
@@ -1,0 +1,1 @@
+"""ROS 2 bridge package for the Duckiematrix state topic."""

--- a/packages/duckiematrix_interface/duckiematrix_interface/duckiematrix_interface_node.py
+++ b/packages/duckiematrix_interface/duckiematrix_interface/duckiematrix_interface_node.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""ROS 2 bridge node for the Duckiematrix state stream."""
+
+import asyncio
+from threading import Thread
+from typing import Optional
+
+import rclpy
+from geometry_msgs.msg import Point, Pose, PoseWithCovariance, Quaternion, Twist, TwistWithCovariance, Vector3
+from nav_msgs.msg import Odometry
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.node import Node as ROS2Node
+
+from dt_robot_utils import get_robot_name
+from dtps import context
+from dtps_http import RawData
+from duckietown_messages.geometry_3d.transformation import Transformation
+from duckietown_messages.geometry_3d.twist import Twist as DTTwist
+from duckietown_messages.utils.exceptions import DataDecodingError
+
+
+class DuckiematrixInterfaceNode(ROS2Node):
+    """Bridge Duckiematrix pose and twist streams into a ROS 2 state topic."""
+
+    def __init__(self) -> None:
+        self._robot_name = get_robot_name()
+        self._previous_pose: Optional[Pose] = None
+        self._state_frame_id = "map"
+        self._child_frame_id = "base_link"
+        self._missing_pose_warned = False
+        super().__init__("duckiematrix_interface_node", namespace=f"/{self._robot_name}")
+
+        self._state_pub = self.create_publisher(Odometry, "~/state", 1)
+
+        self.get_logger().info("Initialized Duckiematrix DTPS bridge.")
+
+    async def _publish_pose(self, data: RawData) -> None:
+        try:
+            pose = Transformation.from_rawdata(data)
+        except DataDecodingError as error:
+            self.get_logger().error(
+                f"Failed to decode pose message: {error.message}"
+            )
+            return
+
+        frame_id = pose.source or pose.header.frame or "map"
+        self._state_frame_id = self._normalize_frame_id(frame_id) or "map"
+        self._previous_pose = Pose(
+            position=Point(
+                x=float(pose.position.x),
+                y=float(pose.position.y),
+                z=float(pose.position.z),
+            ),
+            orientation=Quaternion(
+                x=float(pose.rotation.x),
+                y=float(pose.rotation.y),
+                z=float(pose.rotation.z),
+                w=float(pose.rotation.w),
+            ),
+        )
+
+    async def _publish_twist(self, data: RawData) -> None:
+        try:
+            twist = DTTwist.from_rawdata(data)
+        except DataDecodingError as error:
+            self.get_logger().error(
+                f"Failed to decode twist message: {error.message}"
+            )
+            return
+
+        twist_frame = twist.header.frame or "base_link"
+        self._child_frame_id = self._normalize_frame_id(twist_frame) or "base_link"
+
+        if self._previous_pose is None:
+            if not self._missing_pose_warned:
+                self.get_logger().warning(
+                    "Skipping state publish until a pose message is available."
+                )
+                self._missing_pose_warned = True
+            return
+
+        self._missing_pose_warned = False
+
+        odometry = Odometry()
+        odometry.header.stamp = self.get_clock().now().to_msg()
+        odometry.header.frame_id = self._state_frame_id
+        odometry.child_frame_id = self._child_frame_id
+        odometry.pose = PoseWithCovariance(pose=self._previous_pose)
+        odometry.twist = TwistWithCovariance(
+            twist=Twist(
+                linear=Vector3(
+                    x=float(twist.linear_velocity.x),
+                    y=float(twist.linear_velocity.y),
+                    z=float(twist.linear_velocity.z),
+                ),
+                angular=Vector3(
+                    x=float(twist.angular_velocity.x),
+                    y=float(twist.angular_velocity.y),
+                    z=float(twist.angular_velocity.z),
+                ),
+            )
+        )
+        self._state_pub.publish(odometry)
+
+    async def worker(self) -> None:
+        try:
+            switchboard = (await context("switchboard")).navigate(self._robot_name)
+            pose_queue = await (switchboard / "state" / "pose").until_ready()
+            twist_queue = await (switchboard / "state" / "twist").until_ready()
+
+            await pose_queue.subscribe(self._publish_pose)
+            await twist_queue.subscribe(self._publish_twist)
+
+            self.get_logger().info(
+                "Subscribed to DTPS topics: state/pose, state/twist."
+            )
+        except Exception as error:
+            self.get_logger().error(
+                f"Failed to connect Duckiematrix DTPS topics: {str(error)}"
+            )
+            return
+
+        await self.join()
+
+    async def join(self) -> None:
+        while rclpy.ok():
+            await asyncio.sleep(1)
+
+    def spin(self) -> None:
+        executor = SingleThreadedExecutor()
+        executor.add_node(self)
+        spin_thread = Thread(target=executor.spin, daemon=True)
+        spin_thread.start()
+
+        try:
+            asyncio.run(self.worker())
+        except RuntimeError:
+            if rclpy.ok():
+                self.get_logger().error("An error occurred while running the event loop.")
+                raise
+        finally:
+            shutdown_ok = executor.shutdown(1)
+            if not shutdown_ok:
+                self.get_logger().warning("ROS2 executor did not shut down within 1 second.")
+            spin_thread.join(timeout=1)
+            if spin_thread.is_alive():
+                self.get_logger().warning(
+                    "ROS2 executor thread is still running; skipping node destruction."
+                )
+            else:
+                self.destroy_node()
+
+    @staticmethod
+    def _normalize_frame_id(frame_id: Optional[str]) -> str:
+        if frame_id is None:
+            return ""
+        if isinstance(frame_id, bytes):
+            try:
+                return frame_id.decode("utf-8", errors="ignore")
+            except Exception:
+                return ""
+        return str(frame_id)
+
+
+def main(args: Optional[list[str]] = None) -> None:
+    rclpy.init(args=args)
+    node = DuckiematrixInterfaceNode()
+    try:
+        node.spin()
+    finally:
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/duckiematrix_interface/launch/duckiematrix_interface.launch.py
+++ b/packages/duckiematrix_interface/launch/duckiematrix_interface.launch.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Launch the Duckiematrix DTPS-to-ROS 2 bridge node."""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    """Generate launch description for the Duckiematrix bridge node."""
+
+    robot_name_arg = DeclareLaunchArgument(
+        'robot_name',
+        default_value='',
+        description='Name of the robot namespace'
+    )
+
+    use_sim_time_arg = DeclareLaunchArgument(
+        'use_sim_time',
+        default_value='false',
+        description='Use simulation time'
+    )
+
+    log_level_arg = DeclareLaunchArgument(
+        'log_level',
+        default_value='info',
+        description='Logging level (debug, info, warn, error, fatal)'
+    )
+
+    duckiematrix_interface_node = Node(
+        package='duckiematrix_interface',
+        executable='duckiematrix_interface_node',
+        name='duckiematrix_interface_node',
+        namespace=LaunchConfiguration('robot_name'),
+        parameters=[{
+            'use_sim_time': LaunchConfiguration('use_sim_time'),
+        }],
+        arguments=['--ros-args', '--log-level', LaunchConfiguration('log_level')],
+        output='screen',
+        emulate_tty=True,
+        respawn=True,
+        respawn_delay=2.0,
+    )
+
+    return LaunchDescription([
+        robot_name_arg,
+        use_sim_time_arg,
+        log_level_arg,
+        duckiematrix_interface_node,
+    ])
+
+
+if __name__ == '__main__':
+    generate_launch_description()

--- a/packages/duckiematrix_interface/package.xml
+++ b/packages/duckiematrix_interface/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>duckiematrix_interface</name>
+  <version>0.0.1</version>
+  <description>ROS 2 bridge for the Duckiematrix state topic exposed over DTPS.</description>
+
+  <maintainer email="liam.mcalpine@duckietown.com">Liam McAlpine</maintainer>
+  <license>Duckietown License</license>
+
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>rclpy</depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/packages/duckiematrix_interface/resource/duckiematrix_interface
+++ b/packages/duckiematrix_interface/resource/duckiematrix_interface
@@ -1,0 +1,1 @@
+duckiematrix_interface

--- a/packages/duckiematrix_interface/setup.cfg
+++ b/packages/duckiematrix_interface/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/duckiematrix_interface
+[install]
+install_scripts=$base/lib/duckiematrix_interface

--- a/packages/duckiematrix_interface/setup.py
+++ b/packages/duckiematrix_interface/setup.py
@@ -1,0 +1,30 @@
+from setuptools import setup
+import os
+from glob import glob
+
+
+package_name = 'duckiematrix_interface'
+
+
+setup(
+    name=package_name,
+    version='0.0.1',
+    packages=[package_name],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    maintainer='Liam McAlpine',
+    maintainer_email='liam.mcalpine@duckietown.com',
+    description='ROS 2 bridge for the Duckiematrix state topic exposed over DTPS',
+    license='Duckietown License',
+    tests_require=['pytest'],
+    data_files=[
+        ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+        (os.path.join('share', package_name, 'launch'), glob('launch/*.launch.py')),
+    ],
+    entry_points={
+        'console_scripts': [
+            'duckiematrix_interface_node = duckiematrix_interface.duckiematrix_interface_node:main',
+        ],
+    },
+)


### PR DESCRIPTION
This pull request introduces a new ROS 2 bridge package, `duckiematrix_interface`, which connects the Duckiematrix state topics (pose and twist) exposed over DTPS to a standard ROS 2 `Odometry` topic. The package includes the bridge node, launch files, and all necessary ROS 2 packaging and setup files to enable integration into the Duckietown ecosystem.

**New package: Duckiematrix ROS 2 bridge**

* Node implementation:
  * Added `duckiematrix_interface_node.py`, a ROS 2 node that subscribes to DTPS pose and twist streams, decodes them, and republishes the data as `Odometry` messages on the `~/state` topic. It handles connection management, error logging, and proper frame assignment.
  * Added a module docstring in `__init__.py` describing the package purpose.

* Launch and integration:
  * Added a ROS 2 launch file, `duckiematrix_interface.launch.py`, which declares arguments for robot name, simulation time, and log level, and launches the bridge node with appropriate parameters.
  * Added a shell launcher script, `duckiematrix-interface.sh`, for integration with the Duckietown system.

* Packaging and setup:
  * Added `package.xml`, `setup.py`, `setup.cfg`, and resource files to define the ROS 2 package, its dependencies, and installation details. [[1]](diffhunk://#diff-3868885f30a9d213a8f78987f694b9a08dc5f8abee37f77e98ff0b9cb89cd2feR1-R17) [[2]](diffhunk://#diff-a01e6fe2799ce851393197e380a1681261738a82ca5f0171d6772bb76e5fb718R1-R30) [[3]](diffhunk://#diff-4a6aa169f1a34045493212d4931ffd0d3979b1649b3b3fdcdd5af784f01b99e6R1-R4) [[4]](diffhunk://#diff-54d7e00da9e52116b90b8d408df927b573bc89c0e34c5cc973cffc4d70ef138cR1)