### PR TITLE
DTSW-7982-Refactor-spin-methods-and-improve-shutdown-handling-in-sensor-drivers

### DIFF
--- a/packages/camera_driver/camera_driver/camera_driver_node.py
+++ b/packages/camera_driver/camera_driver/camera_driver_node.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 
 import asyncio
+from threading import Thread
 from typing import Optional
+
 import rclpy
+from rclpy.executors import SingleThreadedExecutor
 from rclpy.node import Node as ROS2Node
 from sensor_msgs.msg import CompressedImage as ROS2CompressedImage, CameraInfo as ROS2CameraInfo
 from dt_node_utils import NodeType
@@ -15,9 +18,6 @@ from duckietown_messages.calibrations.camera_intrinsic import CameraIntrinsicCal
 from duckietown_messages.sensors.camera import Camera
 from duckietown_messages.sensors.compressed_image import CompressedImage
 from duckietown_messages.utils.exceptions import DataDecodingError
-
-SPIN_TIMEOUT_SEC: float = 0.0  # Non-blocking ROS2 spin timeout to keep the asyncio loop free for dtps
-SPIN_PERIOD_SEC: float = 0.02  # Poll rate (50 Hz) for ROS2 spin to maintain parameter service and shutdown responsiveness
 
 
 class CameraNode(Node):
@@ -127,26 +127,40 @@ class CameraNode(Node):
         await self.join()
 
     def spin(self):
+        executor = SingleThreadedExecutor()
+        executor.add_node(self._ros2)
+        spin_thread = Thread(target=executor.spin, daemon=True)
+        spin_thread.start()
+
         try:
             asyncio.run(self.worker())
         except RuntimeError:
             if not self.is_shutdown:
                 self.logerr("An error occurred while running the event loop")
                 raise
+        finally:
+            shutdown_ok = executor.shutdown(1)
+            if not shutdown_ok:
+                self.logwarn("ROS2 executor did not shut down within 1 second.")
+            spin_thread.join(timeout=1)
+            if spin_thread.is_alive():
+                self.logwarn("ROS2 executor thread is still running; skipping node destruction.")
+            else:
+                self._ros2.destroy_node()
 
     async def join(self):
-        while not self.is_shutdown:
-            rclpy.spin_once(self._ros2, timeout_sec=SPIN_TIMEOUT_SEC)
-            await asyncio.sleep(SPIN_PERIOD_SEC)
+        while rclpy.ok():
+            await asyncio.sleep(1)
 
 
 def main(args=None):
     rclpy.init(args=args)
     camera_node = CameraNode()
-    camera_node.spin()
-    # camera_node.worker()
-    # rclpy.spin(camera_node)
-    # rclpy.shutdown()
+    try:
+        camera_node.spin()
+    finally:
+        if rclpy.ok():
+            rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/packages/tof_driver/tof_driver/tof_driver_node.py
+++ b/packages/tof_driver/tof_driver/tof_driver_node.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 
 import asyncio
+from threading import Thread
+
 import rclpy
+from rclpy.executors import SingleThreadedExecutor
 from rclpy.node import Node as ROS2Node
 from sensor_msgs.msg import Range as ROSRange
 from std_msgs.msg import Header
@@ -13,9 +16,6 @@ from duckietown_messages.utils.exceptions import DataDecodingError
 
 MAX_RANGE = 99  # meters
 OUT_OF_RANGE = 999
-
-SPIN_TIMEOUT_SEC: float = 0.0  # Non-blocking ROS2 spin timeout to keep the asyncio loop free for dtps
-SPIN_PERIOD_SEC: float = 0.02  # Poll rate (50 Hz) for ROS2 spin to maintain parameter service and shutdown responsiveness
 
 
 class ToFNode(ROS2Node):
@@ -92,23 +92,39 @@ class ToFNode(ROS2Node):
 
     async def join(self):
         while rclpy.ok():
-            rclpy.spin_once(self, timeout_sec=SPIN_TIMEOUT_SEC)
-            await asyncio.sleep(SPIN_PERIOD_SEC)
+            await asyncio.sleep(1)
 
     def spin(self):
+        executor = SingleThreadedExecutor()
+        executor.add_node(self)
+        spin_thread = Thread(target=executor.spin, daemon=True)
+        spin_thread.start()
+
         try:
             asyncio.run(self.worker())
         except RuntimeError:
             if rclpy.ok():
                 self.get_logger().error("An error occurred while running the event loop")
                 raise
+        finally:
+            shutdown_ok = executor.shutdown(1)
+            if not shutdown_ok:
+                self.get_logger().warning("ROS2 executor did not shut down within 1 second.")
+            spin_thread.join(timeout=1)
+            if spin_thread.is_alive():
+                self.get_logger().warning("ROS2 executor thread is still running; skipping node destruction.")
+            else:
+                self.destroy_node()
 
 
 def main(args=None):
     rclpy.init(args=args)
     tof_node = ToFNode()
-    tof_node.spin()
-    rclpy.shutdown()
+    try:
+        tof_node.spin()
+    finally:
+        if rclpy.ok():
+            rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/packages/wheel_encoder_driver/wheel_encoder_driver/wheel_encoder_driver_node.py
+++ b/packages/wheel_encoder_driver/wheel_encoder_driver/wheel_encoder_driver_node.py
@@ -1,7 +1,9 @@
 import asyncio
 from math import pi
+from threading import Thread
 
 import rclpy
+from rclpy.executors import SingleThreadedExecutor
 from rclpy.node import Node as ROS2Node
 import tf_transformations
 from duckietown_msgs.msg import WheelEncoderStamped
@@ -15,9 +17,6 @@ from duckietown_messages.standard.integer import Integer
 from duckietown_messages.utils.exceptions import DataDecodingError
 
 RESOLUTION: int = 135
-
-SPIN_TIMEOUT_SEC: float = 0.0  # Non-blocking ROS2 spin timeout to keep the asyncio loop free for dtps
-SPIN_PERIOD_SEC: float = 0.02  # Poll rate (50 Hz) for ROS2 spin to maintain parameter service and shutdown responsiveness
 
 
 class WheelEncoderNode(ROS2Node):
@@ -77,23 +76,39 @@ class WheelEncoderNode(ROS2Node):
 
     async def join(self):
         while rclpy.ok():
-            rclpy.spin_once(self, timeout_sec=SPIN_TIMEOUT_SEC)
-            await asyncio.sleep(SPIN_PERIOD_SEC)
+            await asyncio.sleep(1)
 
     def spin(self):
+        executor = SingleThreadedExecutor()
+        executor.add_node(self)
+        spin_thread = Thread(target=executor.spin, daemon=True)
+        spin_thread.start()
+
         try:
             asyncio.run(self.worker())
         except RuntimeError:
             if rclpy.ok():
                 self.get_logger().error("An error occurred while running the event loop")
                 raise
+        finally:
+            shutdown_ok = executor.shutdown(1)
+            if not shutdown_ok:
+                self.get_logger().warning("ROS2 executor did not shut down within 1 second.")
+            spin_thread.join(timeout=1)
+            if spin_thread.is_alive():
+                self.get_logger().warning("ROS2 executor thread is still running; skipping node destruction.")
+            else:
+                self.destroy_node()
 
 
 def main(args=None):
     rclpy.init(args=args)
     wheel_encoder_node = WheelEncoderNode()
-    wheel_encoder_node.spin()
-    rclpy.shutdown()
+    try:
+        wheel_encoder_node.spin()
+    finally:
+        if rclpy.ok():
+            rclpy.shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request refactors the ROS 2 node spinning and shutdown logic in the `camera_driver`, `tof_driver`, and `wheel_encoder_driver` packages. The main improvement is the adoption of a dedicated `SingleThreadedExecutor` running in a background thread for each node, which simplifies the event loop management and ensures a cleaner shutdown process. It also removes the previous polling-based spin logic and replaces it with a more robust threading-based approach.

**Executor and threading refactor:**

* Introduced a `SingleThreadedExecutor` and a background thread (`_spin_thread`) for spinning each ROS 2 node, replacing the manual polling loop and `spin_once` calls in `CameraNode`, `ToFNode`, and `WheelEncoderNode`. This change allows the main thread to run the asyncio event loop without interference from ROS 2 spinning. [[1]](diffhunk://#diff-f8cb6cb48b51f1241005d2fec679da911c174853c4c5fdf7c99e45f8b9f1380aR4-R8) [[2]](diffhunk://#diff-d00cd2d2bbed9f34959e8f1cfd8eb8f4720be245f9958b4e28943d5bdc8bb15bR4-R8) [[3]](diffhunk://#diff-aa2d3e20b272e48900eb1c963c9d5ff501b79a569b4eb55b9e757072815e5abfR3-R7)
* Updated the `spin` methods to start the executor in a separate thread and ensure proper shutdown of both the executor and the thread in a `finally` block, improving resource management and preventing potential deadlocks or resource leaks. [[1]](diffhunk://#diff-f8cb6cb48b51f1241005d2fec679da911c174853c4c5fdf7c99e45f8b9f1380aR132-R164) [[2]](diffhunk://#diff-d00cd2d2bbed9f34959e8f1cfd8eb8f4720be245f9958b4e28943d5bdc8bb15bL95-R128) [[3]](diffhunk://#diff-aa2d3e20b272e48900eb1c963c9d5ff501b79a569b4eb55b9e757072815e5abfL80-R112)
* Removed the old spin timeout and period constants, as well as the manual polling logic in the `join` methods, simplifying the code and making the event loop more efficient. [[1]](diffhunk://#diff-f8cb6cb48b51f1241005d2fec679da911c174853c4c5fdf7c99e45f8b9f1380aL19-L21) [[2]](diffhunk://#diff-d00cd2d2bbed9f34959e8f1cfd8eb8f4720be245f9958b4e28943d5bdc8bb15bL17-L19) [[3]](diffhunk://#diff-aa2d3e20b272e48900eb1c963c9d5ff501b79a569b4eb55b9e757072815e5abfL19-L21)

**Shutdown and cleanup improvements:**

* Modified the `main` functions to ensure `rclpy.shutdown()` is always called after node execution, even if an exception occurs, for all three drivers. [[1]](diffhunk://#diff-f8cb6cb48b51f1241005d2fec679da911c174853c4c5fdf7c99e45f8b9f1380aR132-R164) [[2]](diffhunk://#diff-d00cd2d2bbed9f34959e8f1cfd8eb8f4720be245f9958b4e28943d5bdc8bb15bL95-R128) [[3]](diffhunk://#diff-aa2d3e20b272e48900eb1c963c9d5ff501b79a569b4eb55b9e757072815e5abfL80-R112)

These changes make the node lifecycle management more robust, easier to maintain, and better aligned with ROS 2 best practices.