### PR TITLE
DTSW-7987-Update-node-and-topic-names

### DIFF
--- a/packages/camera_driver/camera_driver/camera_driver_node.py
+++ b/packages/camera_driver/camera_driver/camera_driver_node.py
@@ -23,15 +23,15 @@ from duckietown_messages.utils.exceptions import DataDecodingError
 class CameraNode(Node):
     def __init__(self, camera_name: str = "front_center"):
         super(CameraNode, self).__init__(
-            name="camera",
+            name="camera_node",
             kind=NodeType.DRIVER,
             description="Reads a stream of images from a camera and publishes the frames over ROS",
         )
         self._robot_name = get_robot_name()
         self._camera_name = camera_name
-        self._ros2 = ROS2Node("camera_driver_node")
-        self.pub_img = self._ros2.create_publisher(ROS2CompressedImage, "image/compressed", 1)
-        self.pub_camera_info = self._ros2.create_publisher(ROS2CameraInfo, "camera_info", 1)
+        self._ros2 = ROS2Node("camera_node")
+        self.pub_img = self._ros2.create_publisher(ROS2CompressedImage, "~/image/compressed", 1)
+        self.pub_camera_info = self._ros2.create_publisher(ROS2CameraInfo, "~/camera_info", 1)
         self._has_published = False
         
         # Store camera info and intrinsics

--- a/packages/camera_driver/launch/camera_driver.launch.py
+++ b/packages/camera_driver/launch/camera_driver.launch.py
@@ -38,7 +38,7 @@ def generate_launch_description():
     camera_driver_node = Node(
         package='camera_driver',
         executable='camera_driver_node',
-        name='camera_driver_node',
+        name='camera_node',
         namespace=LaunchConfiguration('robot_name'),
         parameters=[{
             'camera_name': LaunchConfiguration('camera_name'),

--- a/packages/led_driver/led_driver/led_driver_node.py
+++ b/packages/led_driver/led_driver/led_driver_node.py
@@ -49,7 +49,7 @@ class LEDDriverNode(Node):
         self._robot_name = get_robot_name()
         self._lights_name = lights_name
         # subscribers
-        self.sub = self.create_subscription(LEDPattern, "led_pattern", self.led_cb, 1)
+        self.sub = self.create_subscription(LEDPattern, "~/led_pattern", self.led_cb, 1)
         # dtps publishers
         self._pattern: Optional[DTPSContext] = None
         # event loop

--- a/packages/rpi_camera_driver/launch/rpi_camera_driver.launch.py
+++ b/packages/rpi_camera_driver/launch/rpi_camera_driver.launch.py
@@ -25,7 +25,7 @@ def generate_launch_description():
     node = Node(
         package="rpi_camera_driver",
         executable="rpi_camera_driver_node",
-        name="rpi_camera_driver_node",
+        name="camera_node",
         namespace=LaunchConfiguration("robot_name"),
         parameters=[{
             "camera_name": LaunchConfiguration("camera_name"),

--- a/packages/rpi_camera_driver/rpi_camera_driver/rpi_camera_driver_node.py
+++ b/packages/rpi_camera_driver/rpi_camera_driver/rpi_camera_driver_node.py
@@ -2,8 +2,9 @@
 """ROS 2 driver for the Raspberry Pi CSI camera.
 
 Uses picamera2 (libcamera) to capture frames, JPEG-encodes them with OpenCV,
-and publishes `<ns>/image/compressed` (sensor_msgs/CompressedImage) plus
-`<ns>/camera_info` (sensor_msgs/CameraInfo) at the requested framerate.
+and publishes `<ns>/camera_node/image/compressed` (sensor_msgs/CompressedImage)
+plus `<ns>/camera_node/camera_info` (sensor_msgs/CameraInfo) at the requested
+framerate.
 
 Falls back to /dev/video0 via OpenCV + V4L2 when picamera2 is unavailable or
 fails to open the sensor.
@@ -28,7 +29,7 @@ class RpiCameraDriverNode(Node):
     VIDEO_DEVICE = "/dev/video0"
 
     def __init__(self):
-        super().__init__("rpi_camera_driver_node")
+        super().__init__("camera_node")
 
         self.declare_parameter("camera_name", "front_center")
         self.declare_parameter("frame_id", "camera_color_optical_frame")
@@ -50,8 +51,8 @@ class RpiCameraDriverNode(Node):
         self.exposure_mode = str(self.get_parameter("exposure_mode").value)
         self.calibration_file = str(self.get_parameter("calibration_file").value)
 
-        self.pub_image = self.create_publisher(CompressedImage, "image/compressed", 1)
-        self.pub_camera_info = self.create_publisher(CameraInfo, "camera_info", 1)
+        self.pub_image = self.create_publisher(CompressedImage, "~/image/compressed", 1)
+        self.pub_camera_info = self.create_publisher(CameraInfo, "~/camera_info", 1)
 
         self._camera: Optional[Union["Picamera2", cv2.VideoCapture]] = None
         self._use_picamera2 = False
@@ -67,7 +68,7 @@ class RpiCameraDriverNode(Node):
         self._worker = threading.Thread(target=self._capture_loop, daemon=True)
         self._worker.start()
         self.get_logger().info(
-            f"rpi_camera_driver_node started: {self.width}x{self.height} @ "
+            f"camera_node started: {self.width}x{self.height} @ "
             f"{self.framerate:.1f} fps, rotation={self.rotation}, "
             f"backend={'picamera2' if self._use_picamera2 else 'v4l2'}"
         )

--- a/packages/tof_driver/launch/tof_driver.launch.py
+++ b/packages/tof_driver/launch/tof_driver.launch.py
@@ -3,7 +3,7 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, TextSubstitution
 
 
 def generate_launch_description():
@@ -38,7 +38,7 @@ def generate_launch_description():
     tof_driver_node = Node(
         package='tof_driver',
         executable='tof_driver_node',
-        name='tof_driver_node',
+        name=[LaunchConfiguration('sensor_name'), TextSubstitution(text='_tof_driver_node')],
         namespace=LaunchConfiguration('robot_name'),
         parameters=[{
             'sensor_name': LaunchConfiguration('sensor_name'),

--- a/packages/tof_driver/tof_driver/tof_driver_node.py
+++ b/packages/tof_driver/tof_driver/tof_driver_node.py
@@ -21,14 +21,14 @@ OUT_OF_RANGE = 999
 class ToFNode(ROS2Node):
     def __init__(self):
         self._robot_name = get_robot_name()
-        super().__init__('tof_node', namespace=f"/{self._robot_name}")
+        super().__init__('tof_driver_node', namespace=f"/{self._robot_name}")
         # arguments
         self.declare_parameter("sensor_name", "front_center")
         self._sensor_name = self.get_parameter("sensor_name").get_parameter_value().string_value
         # create publisher
         self._pub = self.create_publisher(
             ROSRange,
-            "range",
+            "~/range",
             1
         )
         self.get_logger().info(f"Initialized for {self._sensor_name} sensor.")

--- a/packages/wheel_encoder_driver/launch/wheel_encoder_driver.launch.py
+++ b/packages/wheel_encoder_driver/launch/wheel_encoder_driver.launch.py
@@ -3,7 +3,7 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, TextSubstitution
 
 
 def generate_launch_description():
@@ -38,7 +38,7 @@ def generate_launch_description():
     wheel_encoder_driver_node = Node(
         package='wheel_encoder_driver',
         executable='wheel_encoder_driver_node',
-        name='wheel_encoder_driver_node',
+        name=[LaunchConfiguration('wheel'), TextSubstitution(text='_wheel_encoder_driver_node')],
         namespace=LaunchConfiguration('robot_name'),
         parameters=[{
             'wheel': LaunchConfiguration('wheel'),

--- a/packages/wheel_encoder_driver/wheel_encoder_driver/wheel_encoder_driver_node.py
+++ b/packages/wheel_encoder_driver/wheel_encoder_driver/wheel_encoder_driver_node.py
@@ -23,12 +23,12 @@ class WheelEncoderNode(ROS2Node):
 
     def __init__(self):
         self._robot_name = get_robot_name()
-        super().__init__('wheel_encoder_node')
+        super().__init__('wheel_encoder_driver_node')
         # get parameters
         self.declare_parameter("wheel", "left")  # Default value
         self._wheel = self.get_parameter("wheel").get_parameter_value().string_value
         # publishers
-        self.pub_ticks = self.create_publisher(WheelEncoderStamped, "tick", 1)
+        self.pub_ticks = self.create_publisher(WheelEncoderStamped, "~/tick", 1)
         # tf broadcaster for wheel frame
         self.tf_broadcaster = TransformBroadcaster(self)
         # ---

--- a/packages/wheels_driver/wheels_driver/wheels_driver_node.py
+++ b/packages/wheels_driver/wheels_driver/wheels_driver_node.py
@@ -36,10 +36,10 @@ class WheelsDriverNode(ROS2Node):
 
         # QoS profile for topics
         qos_profile = QoSProfile(depth=10)
-        self.pub_wheels_cmd = self.create_publisher(WheelsCmdStamped, 'wheels_cmd_executed', qos_profile)
-        self.pub_autopilot = self.create_publisher(Bool, 'autopilot', qos_profile)
-        self.create_subscription(WheelsCmdStamped, 'wheels_cmd', self.cmds_cb, qos_profile)
-        self.create_subscription(Bool, 'emergency_stop', self.estop_cb, qos_profile)
+        self.pub_wheels_cmd = self.create_publisher(WheelsCmdStamped, '~/wheels_cmd_executed', qos_profile)
+        self.pub_autopilot = self.create_publisher(Bool, '~/autopilot', qos_profile)
+        self.create_subscription(WheelsCmdStamped, '~/wheels_cmd', self.cmds_cb, qos_profile)
+        self.create_subscription(Bool, '~/emergency_stop', self.estop_cb, qos_profile)
 
         # DTPS context variables
         self._pwm: Optional[DTPSContext] = None


### PR DESCRIPTION
This pull request standardizes and improves topic naming conventions and node names across multiple ROS 2 driver packages. The main changes include switching to private (`~`) topic names for publishers and subscribers, updating node names for consistency, and modifying launch files to use parameterized or descriptive node names. These changes enhance modularity, prevent topic collisions when running multiple instances, and align with ROS best practices.

**Topic Naming Standardization:**

* Changed all publisher and subscriber topic names to use the private namespace (`~`) in the following drivers: camera, RPi camera, LED, ToF, wheel encoder, and wheels driver nodes. This ensures topics are correctly scoped to their respective nodes and prevents conflicts. [[1]](diffhunk://#diff-f8cb6cb48b51f1241005d2fec679da911c174853c4c5fdf7c99e45f8b9f1380aL26-R34) [[2]](diffhunk://#diff-9cf502fc8f5a92d85bd9f53cb73e653babf060fa80738c06dafb4d3e6a41cd8cL52-R52) [[3]](diffhunk://#diff-c331e40452d1f07f9926ea080226d37653b601c4fdcd4e34285fdda9e29775e2L53-R55) [[4]](diffhunk://#diff-d00cd2d2bbed9f34959e8f1cfd8eb8f4720be245f9958b4e28943d5bdc8bb15bL24-R31) [[5]](diffhunk://#diff-aa2d3e20b272e48900eb1c963c9d5ff501b79a569b4eb55b9e757072815e5abfL26-R31) [[6]](diffhunk://#diff-1c2f4ae0c30d61d8ba18ae02d9bbbb2c07cb349d45123addc48d6a188da27018L39-R42)

**Node Naming Consistency:**

* Updated node names in both code and launch files for camera, RPi camera, ToF, and wheel encoder drivers to use more consistent and descriptive names (e.g., `camera_node`, `tof_driver_node`, `wheel_encoder_driver_node`) and, where appropriate, parameterized names for multi-sensor support. [[1]](diffhunk://#diff-f8cb6cb48b51f1241005d2fec679da911c174853c4c5fdf7c99e45f8b9f1380aL26-R34) [[2]](diffhunk://#diff-c331e40452d1f07f9926ea080226d37653b601c4fdcd4e34285fdda9e29775e2L31-R32) [[3]](diffhunk://#diff-c331e40452d1f07f9926ea080226d37653b601c4fdcd4e34285fdda9e29775e2L70-R71) [[4]](diffhunk://#diff-fb1161ef7a892609d028f276f3ca32ae949474c56eaf8d064b2630288548739bL41-R41) [[5]](diffhunk://#diff-4d757ab819597f184b3adbedb5e3c47effa747af9424fbb455f277daa436e755L28-R28) [[6]](diffhunk://#diff-dd82a2c30125c8d82003d0b6b33a214aa4664974d4a31442165d3eaccf477cf6L41-R41) [[7]](diffhunk://#diff-148b63a8fa33350461621d7a316f0ff982ecee44f3af97f8c664391365d7e8d3L41-R41) [[8]](diffhunk://#diff-d00cd2d2bbed9f34959e8f1cfd8eb8f4720be245f9958b4e28943d5bdc8bb15bL24-R31) [[9]](diffhunk://#diff-aa2d3e20b272e48900eb1c963c9d5ff501b79a569b4eb55b9e757072815e5abfL26-R31)

**Documentation Updates:**

* Updated docstrings and log messages in the RPi camera driver to reflect the new topic and node names for clarity and accuracy. [[1]](diffhunk://#diff-c331e40452d1f07f9926ea080226d37653b601c4fdcd4e34285fdda9e29775e2L5-R7) [[2]](diffhunk://#diff-c331e40452d1f07f9926ea080226d37653b601c4fdcd4e34285fdda9e29775e2L70-R71)

**Launch File Improvements:**

* Modified launch files to use parameterized or concatenated node names for ToF and wheel encoder drivers, supporting multiple sensors and preventing node name clashes. [[1]](diffhunk://#diff-dd82a2c30125c8d82003d0b6b33a214aa4664974d4a31442165d3eaccf477cf6L41-R41) [[2]](diffhunk://#diff-148b63a8fa33350461621d7a316f0ff982ecee44f3af97f8c664391365d7e8d3L41-R41)

These changes collectively improve maintainability, scalability, and reliability when deploying multiple instances of these drivers on a single robot or across different robots.