### PR TITLE
DTSW-7986-Update-Dashboard

### DIFF
--- a/packages/rosbridge_websocket/CMakeLists.txt
+++ b/packages/rosbridge_websocket/CMakeLists.txt
@@ -14,6 +14,11 @@ install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
 
+install(PROGRAMS
+  rosbridge_websocket_compat.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights

--- a/packages/rosbridge_websocket/launch/rosbridge_websocket.launch.py
+++ b/packages/rosbridge_websocket/launch/rosbridge_websocket.launch.py
@@ -76,8 +76,8 @@ def generate_launch_description():
 
     # Create nodes
     rosbridge_websocket_node = Node(
-        package='rosbridge_server',
-        executable='rosbridge_websocket',
+        package='rosbridge_websocket',
+        executable='rosbridge_websocket_compat.py',
         name='rosbridge_websocket',
         namespace=LaunchConfiguration('veh'),
         output='screen',

--- a/packages/rosbridge_websocket/rosbridge_websocket_compat.py
+++ b/packages/rosbridge_websocket/rosbridge_websocket_compat.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+import json
+from pathlib import Path
+import runpy
+import shutil
+import sys
+from numbers import Real
+from typing import Any
+
+
+def _normalize_legacy_name(value: Any) -> Any:
+    if isinstance(value, str) and value.startswith("//"):
+        return value.lstrip("/")
+    return value
+
+
+def _normalize_service_name(value: Any) -> Any:
+    value = _normalize_legacy_name(value)
+    if isinstance(value, str) and value.startswith("/rosapi/"):
+        return value.lstrip("/")
+    return value
+
+
+def _normalize_throttle_rate(value: Any) -> Any:
+    if isinstance(value, Real) and not isinstance(value, bool):
+        return max(0, int(round(float(value))))
+    return value
+
+
+def _normalize_message(payload: Any) -> Any:
+    if isinstance(payload, dict):
+        normalized = {}
+        for key, value in payload.items():
+            if key in {"topic", "action"}:
+                normalized[key] = _normalize_legacy_name(value)
+            elif key == "service":
+                normalized[key] = _normalize_service_name(value)
+            elif key == "throttle_rate":
+                normalized[key] = _normalize_throttle_rate(value)
+            else:
+                normalized[key] = _normalize_message(value)
+        return normalized
+
+    if isinstance(payload, list):
+        return [_normalize_message(item) for item in payload]
+
+    return payload
+
+
+def _patch_rosbridge_websocket() -> None:
+    from rosbridge_server.websocket_handler import RosbridgeWebSocket
+
+    original_on_message = RosbridgeWebSocket.on_message
+
+    def patched_on_message(self, message: str | bytes) -> None:
+        if isinstance(message, bytes):
+            message = message.decode("utf-8")
+
+        try:
+            payload = json.loads(message)
+        except Exception:
+            original_on_message(self, message)
+            return
+
+        normalized = _normalize_message(payload)
+        if normalized != payload:
+            message = json.dumps(normalized, separators=(",", ":"))
+
+        original_on_message(self, message)
+
+    RosbridgeWebSocket.on_message = patched_on_message
+
+
+def _find_upstream_executable() -> str:
+    candidates: list[Path] = []
+
+    try:
+        from ament_index_python.packages import get_package_prefix
+    except ImportError:
+        get_package_prefix = None
+
+    if get_package_prefix is not None:
+        package_prefix = get_package_prefix("rosbridge_server")
+        prefix_path = Path(package_prefix)
+        libexec_dir = prefix_path / "lib" / "rosbridge_server"
+        candidates.append(libexec_dir / "rosbridge_websocket")
+        candidates.append(libexec_dir / "rosbridge_websocket.py")
+
+    executable_path = shutil.which("rosbridge_websocket")
+    if executable_path is not None:
+        candidates.append(Path(executable_path))
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+
+    raise RuntimeError("Could not locate upstream rosbridge_websocket executable")
+
+
+def main() -> None:
+    upstream = _find_upstream_executable()
+
+    _patch_rosbridge_websocket()
+
+    original_argv0 = sys.argv[0]
+    try:
+        sys.argv[0] = upstream
+        runpy.run_path(upstream, run_name="__main__")
+    finally:
+        sys.argv[0] = original_argv0
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces a compatibility wrapper for the `rosbridge_websocket` node, updating the launch process to use this new wrapper and ensuring it is installed correctly. The primary goal is to intercept and normalize incoming messages for legacy compatibility, without modifying the upstream `rosbridge_server` package.

**Compatibility Wrapper Introduction and Launch Update:**

* Added a new executable script, `rosbridge_websocket_compat.py`, which acts as a wrapper around the upstream `rosbridge_websocket` node. This wrapper normalizes message fields (such as topic, service, and throttle_rate) for legacy compatibility before passing them to the original node.
* Updated the launch file (`rosbridge_websocket.launch.py`) to launch the new `rosbridge_websocket_compat.py` script from the local package instead of the upstream executable, ensuring the wrapper is used in deployments.

**Installation and Packaging:**

* Modified the CMake configuration to install the `rosbridge_websocket_compat.py` script as a program in the appropriate location within the package, so it is available for execution after installation.