### PR TITLE
add GCS bridge for FC

### DIFF
--- a/launchers/mavros.sh
+++ b/launchers/mavros.sh
@@ -24,9 +24,19 @@ if [ "${ROBOT_HARDWARE}" == "virtual" ]; then
 else
   FCU_URL=${FCU_URL:-"serial:///dev/ttyACM0:57600"}
 fi
+
+# GCS bridge: MAVROS forwards the FC MAVLink stream to a ground control station
+# (e.g. QGroundControl) over this endpoint. On real hardware MAVROS owns the FC
+# serial port, so this is the supported way to reach the FC from QGC without a
+# second process contending for /dev/ttyACM0. QGC connects as a TCP client to
+# <robot-ip>:5760 (container runs with network_mode: host). An explicit GCS_URL
+# env variable always takes precedence.
+GCS_URL=${GCS_URL:-"tcp-l://:5760"}
+
 MAVROS_CONFIG=${MAVROS_CONFIG:-"${DT_PROJECT_PATH}/assets/mavros/px4_config.yaml"}
 dt-exec ros2 run mavros mavros_node --ros-args \
     -p "fcu_url:=${FCU_URL}" \
+    -p "gcs_url:=${GCS_URL}" \
     --params-file "${MAVROS_CONFIG}"
 
 # wait for app to end


### PR DESCRIPTION
On a real DD24, QGroundControl cannot connect to the flight controller over TCP 5760 — nothing in the ente stack opens that port on hardware (the docs' 5760 endpoint only exists on the virtual drone). 

MAVROS already owns the FC serial (/dev/ttyACM0), so enable its built-in GCS bridge by setting gcs_url:=tcp-l://:5760 in dt-ros2-interface/launchers/mavros.sh. 

Since ros2-mavros runs with host networking, QGC then connects to <robot-ip>:5760. 