### PR TITLE
DTSW-8070-Bump-up-Baud-Rate-for-Pi-FC-Serial-Link

### DIFF
--- a/assets/mavros/px4_config.yaml
+++ b/assets/mavros/px4_config.yaml
@@ -1,10 +1,6 @@
 # MAVROS plugin parameter overrides for the Duckiedrone (PX4).
 #
-# Loaded by launchers/mavros.sh via `--params-file`. Without this, mavros runs
-# on built-in defaults. In that mode, `setpoint_attitude.use_quaternion` is
-# false, so the setpoint_attitude plugin consumes `cmd_vel` rather than the
-# `attitude` PoseStamped interface used by the current attitude+thrust
-# OFFBOARD controller.
+# Loaded by launchers/mavros.sh via `--params-file`.
 #
 # The `/**/` glob applies these to the mavros plugin component nodes
 # (e.g. /mavros/setpoint_attitude).
@@ -16,3 +12,9 @@
 /**/setpoint_raw:
   ros__parameters:
     thrust_scaling: 1.0         # PX4 expects normalized [0,1] thrust (no scaling)
+
+# Disable MAVROS plugins we do not use on this airframe.
+# By default they cram up the serial bus
+/mavros:
+  ros__parameters:
+    plugin_denylist: ["geofence", "rallypoint"]

--- a/launchers/mavros.sh
+++ b/launchers/mavros.sh
@@ -9,20 +9,15 @@ source /environment.sh
 # NOTE: Use `dt-exec COMMAND` to run the main process (blocking process)
 
 # Launch MAVROS
-# The params file enables quaternion attitude setpoints for the MAVROS
-# setpoint_attitude plugin and sets setpoint_raw.thrust_scaling=1.0.
-# Without it, MAVROS uses its built-in defaults and the current
-# PoseStamped+thrust OFFBOARD control path is not consumed.
 #
-# Select the MAVLink endpoint based on the robot hardware:
-#   - virtual robots: PX4 SITL exposes MAVLink over UDP on port 14540
-#   - real robots:    the PX4 flight controller is connected over USB (CDC-ACM),
-#                     enumerating as /dev/ttyACM0 (baud is nominal for CDC-ACM)
+# Select the MAVLink endpoint based on robot hardware:
+#   - virtual robots: connect over UDP port 14540
+#   - real robots:    connect over serial /dev/ttyACM0 with 921600 baud (recommended by PX4)
 # An explicit FCU_URL environment variable always takes precedence.
 if [ "${ROBOT_HARDWARE}" == "virtual" ]; then
   FCU_URL=${FCU_URL:-"udp://:14540@"}
 else
-  FCU_URL=${FCU_URL:-"serial:///dev/ttyACM0:57600"}
+  FCU_URL=${FCU_URL:-"serial:///dev/ttyACM0:921600"}
 fi
 MAVROS_CONFIG=${MAVROS_CONFIG:-"${DT_PROJECT_PATH}/assets/mavros/px4_config.yaml"}
 dt-exec ros2 run mavros mavros_node --ros-args \


### PR DESCRIPTION
Baud 57600 → 921600 (DTSW-8070): 57600 was too slow; the param pull maxed out the link, and arming commands kept stalling. 
Bumped it to 921600 (what PX4 recommends for companion links). 
Only touches the real-robot serial:// branch; virtual is unchanged.

Deny-list geofence + rallypoint (DTSW-8071): 
These are GPS-only features, and the DD24 has no GPS, so they just sat there polling the FC and retrying forever, which spammed the serial link. Deny-listed them so they don't load. Nothing lost.