### PR TITLE
DTSW-8142-Forward-the-Bottom-ToF-Sensor-readings-to-FC-for-Height-Estimation

### DIFF
--- a/assets/mavros/px4_config.yaml
+++ b/assets/mavros/px4_config.yaml
@@ -13,8 +13,41 @@
   ros__parameters:
     thrust_scaling: 1.0         # PX4 expects normalized [0,1] thrust (no scaling)
 
-# Disable MAVROS plugins we do not use on this airframe.
-# By default they cram up the serial bus
+# Send the bottom ToF reading to the FC as a height source (from mavros_extras).
+/**/distance_sensor:
+  ros__parameters:
+    config: |
+      bottom_tof:
+        subscriber: true          # we send data to the FC, not read from it
+        id: 0
+        orientation: PITCH_270    # sensor faces straight down
+        horizontal_fov_ratio: 1.0
+        vertical_fov_ratio: 1.0
+
+# Only load the plugins we actually use, so mavros_extras doesn't flood the serial link.
 /mavros:
   ros__parameters:
-    plugin_denylist: ["geofence", "rallypoint"]
+    plugin_allowlist:
+      - actuator_control
+      - altitude
+      - command
+      - ftp
+      - global_position
+      - home_position
+      - imu
+      - local_position
+      - manual_control
+      - nav_controller_output
+      - param
+      - rc_io
+      - setpoint_accel
+      - setpoint_attitude
+      - setpoint_position
+      - setpoint_raw
+      - setpoint_trajectory
+      - setpoint_velocity
+      - sys_status
+      - sys_time
+      - waypoint
+      - wind_estimation
+      - distance_sensor

--- a/dependencies-apt.txt
+++ b/dependencies-apt.txt
@@ -24,3 +24,4 @@ ros-jazzy-rosbridge-suite
 ros-jazzy-rosapi
 ros-jazzy-foxglove-bridge
 ros-jazzy-mavros
+ros-jazzy-mavros-extras

--- a/launchers/mavros.sh
+++ b/launchers/mavros.sh
@@ -20,8 +20,27 @@ else
   FCU_URL=${FCU_URL:-"serial:///dev/ttyACM0:921600"}
 fi
 MAVROS_CONFIG=${MAVROS_CONFIG:-"${DT_PROJECT_PATH}/assets/mavros/px4_config.yaml"}
+# Bridge the real ToF topic onto what the distance_sensor plugin expects (see px4_config.yaml).
+TOF_RANGE_TOPIC=${TOF_RANGE_TOPIC:-"/${HOSTNAME}/bottom_tof_driver_node/range"}
+
+# PX4 echoes our ToF data back out, which spams a harmless error in the mavros log.
+# Tell it to stop (MAV_CMD 511). This doesn't persist on the FC, so redo it every launch,
+# once the FC link is actually up (no fixed delay — poll instead of guessing).
+(
+  for _ in $(seq 1 30); do
+    grep -q "connected: true" <(ros2 topic echo /mavros/state --once 2>/dev/null) && break
+    sleep 2
+  done
+  for _ in 1 2 3 4 5 6; do
+    ros2 service call /mavros/cmd/command mavros_msgs/srv/CommandLong \
+      "{command: 511, param1: 132.0, param2: -1.0}" >/dev/null 2>&1 && break
+    sleep 5
+  done
+) &
+
 dt-exec ros2 run mavros mavros_node --ros-args \
     -p "fcu_url:=${FCU_URL}" \
+    -r "/mavros/bottom_tof:=${TOF_RANGE_TOPIC}" \
     --params-file "${MAVROS_CONFIG}"
 
 # wait for app to end

--- a/launchers/mavros.sh
+++ b/launchers/mavros.sh
@@ -33,7 +33,7 @@ TOF_RANGE_TOPIC=${TOF_RANGE_TOPIC:-"/${HOSTNAME}/bottom_tof_driver_node/range"}
   done
   for _ in 1 2 3 4 5 6; do
     ros2 service call /mavros/cmd/command mavros_msgs/srv/CommandLong \
-      "{command: 511, param1: 132.0, param2: -1.0}" >/dev/null 2>&1 && break
+      "{broadcast: false, command: 511, confirmation: 0, param1: 132.0, param2: -1.0, param3: 0.0, param4: 0.0, param5: 0.0, param6: 0.0, param7: 0.0}" >/dev/null 2>&1 && break
     sleep 5
   done
 ) &


### PR DESCRIPTION
Adds real-height data to the FC on real hardware. 
Right now, the FC has no absolute height source, so it can only arm and fly in STABILIZED. 
This lets PX4's EKF2 use the bottom ToF sensor for height, which is what clears OFFBOARD to arm.

Three changes, all needed together:

`dependencies-apt.txt`: add ros-jazzy-mavros-extras. 
The distance_sensor plugin lives here, not in base mavros, and this package was never installed before, so the plugin had nothing to load.

`assets/mavros/px4_config.yaml`: configure distance_sensor to subscribe to the bottom ToF and forward it to the FC (downward-facing, PITCH_270). 
Also switch plugin_denylist to an explicit plugin_allowlist, since installing mavros_extras pulls in about 40 plugins by default and otherwise floods the serial bus.

`launchers/mavros.sh`: remap the plugin's expected topic onto the real ToF topic, 
And send a SET_MESSAGE_INTERVAL command once the FC link is up to stop PX4 echoing our own data back at us (that echo isn't persistent on the FC, so it has to be resent on every launch; there's no PX4 param for this, confirmed against the PX4 and mavros source).