### PR TITLE
DTSW-8166-Fix-Gyro-calibration-service-timeout-bug

### DIFF
--- a/packages/px4_calibration/px4_calibration/px4_calibration_node.py
+++ b/packages/px4_calibration/px4_calibration/px4_calibration_node.py
@@ -24,7 +24,9 @@ class PX4CalibrationNode(Node):
         self.declare_parameter("status_text_topic", "/mavros/statustext/recv")
         self.declare_parameter("gyro_timeout_sec", 45.0)
         # Assume success this long after an accepted command if no STATUSTEXT arrives
-        # (PX4 >=1.15 reports cal over events, not STATUSTEXT). Both cals are quick.
+        # (PX4 >=1.15 reports cal over events, not STATUSTEXT). Gyro and level are both
+        # quick when the vehicle is still; see grace_deadline handling below for the
+        # motion-retry case where this assumption does not hold.
         self.declare_parameter("gyro_statustext_grace_sec", 5.0)
         # Level-horizon cal: one-shot board-level trim (param5=2), also non-interactive.
         self.declare_parameter("level_timeout_sec", 45.0)
@@ -141,9 +143,10 @@ class PX4CalibrationNode(Node):
                 return response
 
             # Prefer a precise "[cal] done/fail" STATUSTEXT, but PX4 >=1.15 sends none
-            # (cal status goes over events instead). So if a grace is allowed (gyro) and
-            # no STATUSTEXT shows up, accept the command ack as success; without this the
-            # service always times out despite the cal running and writing CAL_* offsets.
+            # (cal status goes over events instead). So if a grace is configured (gyro and
+            # level both set one) and no STATUSTEXT shows up, accept the command ack as
+            # success; without this the service always times out despite the cal running
+            # and writing CAL_*/SENS_BOARD_* offsets.
             start = time.monotonic()
             deadline = start + timeout_sec
             grace_deadline = (

--- a/packages/px4_calibration/px4_calibration/px4_calibration_node.py
+++ b/packages/px4_calibration/px4_calibration/px4_calibration_node.py
@@ -23,7 +23,6 @@ class PX4CalibrationNode(Node):
         self.declare_parameter("command_service", "/mavros/cmd/command")
         self.declare_parameter("status_text_topic", "/mavros/statustext/recv")
         self.declare_parameter("gyro_timeout_sec", 45.0)
-        self.declare_parameter("accel_timeout_sec", 180.0)
         # Assume gyro success this long after an accepted command if no STATUSTEXT arrives
         # (PX4 >=1.15 reports cal over events, not STATUSTEXT). Gyro cal is quick.
         self.declare_parameter("gyro_statustext_grace_sec", 5.0)
@@ -52,12 +51,6 @@ class PX4CalibrationNode(Node):
             self._calibrate_gyro_cb,
             callback_group=self._callback_group,
         )
-        self.create_service(
-            Trigger,
-            "/px4_calibration/calibrate_accel",
-            self._calibrate_accel_cb,
-            callback_group=self._callback_group,
-        )
 
         self.get_logger().info("PX4 calibration services ready.")
 
@@ -84,18 +77,6 @@ class PX4CalibrationNode(Node):
             statustext_grace_sec=float(
                 self.get_parameter("gyro_statustext_grace_sec").value
             ),
-        )
-
-    def _calibrate_accel_cb(self, _request, response):
-        # No grace fallback: accel cal is interactive (6 orientations) and can't be
-        # confirmed without the per-step prompts, which this firmware sends as events.
-        return self._run_calibration(
-            response=response,
-            name="accel",
-            timeout_sec=float(self.get_parameter("accel_timeout_sec").value),
-            param1=0.0,
-            param5=1.0,
-            statustext_grace_sec=None,
         )
 
     def _run_calibration(

--- a/packages/px4_calibration/px4_calibration/px4_calibration_node.py
+++ b/packages/px4_calibration/px4_calibration/px4_calibration_node.py
@@ -24,6 +24,9 @@ class PX4CalibrationNode(Node):
         self.declare_parameter("status_text_topic", "/mavros/statustext/recv")
         self.declare_parameter("gyro_timeout_sec", 45.0)
         self.declare_parameter("accel_timeout_sec", 180.0)
+        # Assume gyro success this long after an accepted command if no STATUSTEXT arrives
+        # (PX4 >=1.15 reports cal over events, not STATUSTEXT). Gyro cal is quick.
+        self.declare_parameter("gyro_statustext_grace_sec", 5.0)
 
         self._callback_group = ReentrantCallbackGroup()
         self._command_client = self.create_client(
@@ -78,15 +81,21 @@ class PX4CalibrationNode(Node):
             timeout_sec=float(self.get_parameter("gyro_timeout_sec").value),
             param1=1.0,
             param5=0.0,
+            statustext_grace_sec=float(
+                self.get_parameter("gyro_statustext_grace_sec").value
+            ),
         )
 
     def _calibrate_accel_cb(self, _request, response):
+        # No grace fallback: accel cal is interactive (6 orientations) and can't be
+        # confirmed without the per-step prompts, which this firmware sends as events.
         return self._run_calibration(
             response=response,
             name="accel",
             timeout_sec=float(self.get_parameter("accel_timeout_sec").value),
             param1=0.0,
             param5=1.0,
+            statustext_grace_sec=None,
         )
 
     def _run_calibration(
@@ -96,6 +105,7 @@ class PX4CalibrationNode(Node):
         timeout_sec: float,
         param1: float,
         param5: float,
+        statustext_grace_sec: Optional[float] = None,
     ):
         if not self._calibration_lock.acquire(blocking=False):
             response.success = False
@@ -128,12 +138,23 @@ class PX4CalibrationNode(Node):
                 self._publish_status(response.message)
                 return response
 
-            deadline = time.monotonic() + timeout_sec
+            # Prefer a precise "[cal] done/fail" STATUSTEXT, but PX4 >=1.15 sends none
+            # (cal status goes over events instead). So if a grace is allowed (gyro) and
+            # no STATUSTEXT shows up, accept the command ack as success; without this the
+            # service always times out despite the cal running and writing CAL_* offsets.
+            start = time.monotonic()
+            deadline = start + timeout_sec
+            grace_deadline = (
+                start + statustext_grace_sec if statustext_grace_sec is not None else None
+            )
             done_text = f"calibration done: {name}"
+            saw_cal_text = False
             while time.monotonic() < deadline and rclpy.ok():
                 with self._status_lock:
                     status = self._last_status_text or ""
                 lower_status = status.lower()
+                if status.startswith("[cal]"):
+                    saw_cal_text = True
                 if done_text in lower_status:
                     response.success = True
                     response.message = status
@@ -142,6 +163,20 @@ class PX4CalibrationNode(Node):
                 if status.startswith("[cal]") and "fail" in lower_status:
                     response.success = False
                     response.message = status
+                    self._publish_status(status)
+                    return response
+                if (
+                    grace_deadline is not None
+                    and not saw_cal_text
+                    and time.monotonic() > grace_deadline
+                ):
+                    response.success = True
+                    response.message = (
+                        f"PX4 {name} calibration command accepted. This firmware sends no "
+                        "STATUSTEXT confirmation (calibration status is reported over the "
+                        "MAVLink event protocol); assuming complete."
+                    )
+                    self._publish_status(response.message)
                     return response
                 time.sleep(0.1)
 

--- a/packages/px4_calibration/px4_calibration/px4_calibration_node.py
+++ b/packages/px4_calibration/px4_calibration/px4_calibration_node.py
@@ -23,9 +23,12 @@ class PX4CalibrationNode(Node):
         self.declare_parameter("command_service", "/mavros/cmd/command")
         self.declare_parameter("status_text_topic", "/mavros/statustext/recv")
         self.declare_parameter("gyro_timeout_sec", 45.0)
-        # Assume gyro success this long after an accepted command if no STATUSTEXT arrives
-        # (PX4 >=1.15 reports cal over events, not STATUSTEXT). Gyro cal is quick.
+        # Assume success this long after an accepted command if no STATUSTEXT arrives
+        # (PX4 >=1.15 reports cal over events, not STATUSTEXT). Both cals are quick.
         self.declare_parameter("gyro_statustext_grace_sec", 5.0)
+        # Level-horizon cal: one-shot board-level trim (param5=2), also non-interactive.
+        self.declare_parameter("level_timeout_sec", 45.0)
+        self.declare_parameter("level_statustext_grace_sec", 5.0)
 
         self._callback_group = ReentrantCallbackGroup()
         self._command_client = self.create_client(
@@ -49,6 +52,12 @@ class PX4CalibrationNode(Node):
             Trigger,
             "/px4_calibration/calibrate_gyro",
             self._calibrate_gyro_cb,
+            callback_group=self._callback_group,
+        )
+        self.create_service(
+            Trigger,
+            "/px4_calibration/calibrate_level",
+            self._calibrate_level_cb,
             callback_group=self._callback_group,
         )
 
@@ -76,6 +85,18 @@ class PX4CalibrationNode(Node):
             param5=0.0,
             statustext_grace_sec=float(
                 self.get_parameter("gyro_statustext_grace_sec").value
+            ),
+        )
+
+    def _calibrate_level_cb(self, _request, response):
+        return self._run_calibration(
+            response=response,
+            name="level",
+            timeout_sec=float(self.get_parameter("level_timeout_sec").value),
+            param1=0.0,
+            param5=2.0,
+            statustext_grace_sec=float(
+                self.get_parameter("level_statustext_grace_sec").value
             ),
         )
 


### PR DESCRIPTION
The gyro calibration ROS service always reported failure, even though the calibration on the flight controller actually worked. Pressing GYRO on the dashboard, or calling `/px4_calibration/calibrate_gyro`, would hang for 45s and then return `success=False`.

Root cause: the node decided success by watching `/mavros/statustext/recv` for the text `calibration done: gyro`. PX4 1.15.4 on the DD24 never sends that. It reports calibration status over the newer MAVLink event protocol instead, which never reaches the statustext topic. I confirmed this live on pdrone24 over a direct link: during a calibration `/mavros/statustext/recv` stays completely empty, while the FCU logs the result as `EVENT 133277` and mavros exposes no topic for events. Meanwhile the command was accepted and the `CAL_GYRO0_*` offsets did get written. So the calibration ran fine, only the completion check was broken.

## Changes

- **Fix gyro timeout:** if the command is accepted and no `[cal]` statustext arrives within a short grace window (`gyro_statustext_grace_sec`, default 5s), report success. The precise `[cal]` done/fail path is kept for firmware that does emit statustext, and a rejected command still fails immediately via the COMMAND_ACK.
- **Remove accel calibration:** dropped the `/px4_calibration/calibrate_accel` service, its callback and `accel_timeout_sec`. Accel cal is interactive (6 orientations with per-step prompts) and cannot work through a single fire-and-forget Trigger call. The interactive CLI in `manual_calibration.py` keeps its accel path.
- **Add level-horizon calibration:** new `/px4_calibration/calibrate_level` service (`PREFLIGHT_CALIBRATION` param5=2). This one is one-shot and non-interactive, so it fits a dashboard button. It writes the board level trim `SENS_BOARD_X_OFF` / `SENS_BOARD_Y_OFF` and reuses the same grace handling.

## Why the completion check is a timer and not an observation

Worth spelling out, since the grace window is not an obvious design choice.

PX4 answers `MAV_CMD_PREFLIGHT_CALIBRATION` with `ACCEPTED` before it runs anything. The commander checks only that the vehicle is disarmed and the worker thread is free, then hands the calibration to that worker and acks (`Commander.cpp:1263-1312`, v1.15.4). So the ACK proves the request was well formed, not that the calibration succeeded. The real outcome goes out as a MAVLink event, which we cannot read. That leaves the node two signals: an ACK that says nothing about the result, and a wall clock. The grace window is the second of those.

## Known limitation

The grace is a timer, so it assumes the worker thread is done at 5s. On a still drone it is: gyro collects 250 samples (roughly 1 to 2s), level samples for 500ms. It does not hold when PX4 detects motion, because both calibrations retry rather than fail fast:

- gyro retries up to 21 times, then reports `ERROR: Motion during calibration` (`gyro_calibration.cpp:197-240`)
- level retries up to 50 times at 500ms each, roughly 25s, then fails and leaves `SENS_BOARD_X_OFF` / `SENS_BOARD_Y_OFF` untouched (`level_calibration.cpp:84-135`)

Level's motion threshold is 0.5 degrees peak to peak, which a running fan or a springy bench can trip. In that case the service returns success at 5s and PX4 fails the calibration up to 20s later, with nothing written and nothing reported. There is a knock-on effect too: the node releases its lock at 5s while PX4's worker thread is still busy, so a calibration requested in that window is rejected with `TEMPORARILY_REJECTED` and surfaces as an unexplained `success=False`.

Note the direction of the error. The old behaviour was wrong the safe way (always reported failure, even on success). This is wrong the unsafe way (reports success even on failure). For gyro that trade is fine, since success is the common case and I verified the write happens. Level is the weaker half of this PR: its motion failure mode is realistic on a bench, and it has not been exercised on hardware yet.

## Approaches considered

1. **Wait for real STATUSTEXT.** Not available to us. PX4 only emits calibration STATUSTEXT when it believes a GCS is connected (mavros#1885), which means setting `gcs_url`. GCS presence couples into the PX4 datalink-loss failsafe (`NAV_DLL_ACT`), the exact parameter we set to 0 so the drone can arm and fly. That route fights our arming fix, so it is out.
2. **Decode the event.** The correct long-term answer, since `EVENT 133277` already reaches us. It needs event-protocol support that mavros does not expose today, so it is a larger piece of work than this bugfix.
3. **Parameter readback as a success detector.** Rejected for gyro: two good calibrations differ only at noise level, so a near-zero diff cannot distinguish "ran" from "did not run", and `ros2 param get` on mavros returned a stale cache even after a forced `param/pull`. Usable for manual spot checks only. More tractable for level, where a failure leaves `SENS_BOARD_*` bit identical.

## Verification

Validated on pdrone24 (gyro path). The service now returns success in about 9s instead of failing at 45s. To confirm the calibration itself really runs, I set `CAL_GYRO0_XOFF=9.9` as a sentinel and ran a calibration: PX4 overwrote it with a fresh plausible bias (`-0.01269`, against `-0.01206` beforehand, a noise-level delta consistent with a genuine recalibration). The level service has not been run on hardware.

## Breaking change

Removing `/px4_calibration/calibrate_accel` and the `accel_timeout_sec` parameter is a breaking API change for anything calling that service. The Duckiedrone dashboard block and mission config are already on `calibrate_level`, so nothing breaks there, but `book-opmanual-dd24` still documents the removed service in `30-duckiedrone-setup-and-config/50-sensor-calibrations.md` and needs a paired docs update.
