### PR TITLE
DTSW-8095-Add-optical_flow-package-to-dt-ros2-core

### DIFF
--- a/packages/camera_driver/camera_driver/camera_driver_node.py
+++ b/packages/camera_driver/camera_driver/camera_driver_node.py
@@ -56,13 +56,13 @@ class CameraNode(Node):
         self.pub_img.publish(msg)
         
         # Publish camera info alongside the image
-        self.publish_camera_info()
+        self.publish_camera_info(msg)
         
         if not self._has_published:
             self.loginfo("Published the first image.")
             self._has_published = True
 
-    def publish_camera_info(self):
+    def publish_camera_info(self, image_msg: ROS2CompressedImage):
         if self.camera_intrinsics is None:
             self.loginfo("No camera intrinsic parameters received yet")
             return
@@ -72,8 +72,8 @@ class CameraNode(Node):
             return
 
         msg = ROS2CameraInfo()
-        msg.header.stamp = self._ros2.get_clock().now().to_msg()
-        msg.header.frame_id = "camera_color_optical_frame"  # TODO: use self.camera_intrinsics.header.frame
+        msg.header.stamp = image_msg.header.stamp
+        msg.header.frame_id = image_msg.header.frame_id
         msg.width = self.camera_info.width
         msg.height = self.camera_info.height
         msg.distortion_model = "plumb_bob"


### PR DESCRIPTION
This pull request updates how camera info messages are published to ensure their headers match the associated image messages. Now, the camera info uses the timestamp and frame ID from the image message, improving synchronization between image and camera info topics.

**Synchronization improvements:**

* The `publish_camera_info` method now takes the image message as a parameter and sets the camera info message's header fields (`stamp` and `frame_id`) to match the image message, ensuring accurate time and frame alignment between published images and camera info. [[1]](diffhunk://#diff-f8cb6cb48b51f1241005d2fec679da911c174853c4c5fdf7c99e45f8b9f1380aL59-R65) [[2]](diffhunk://#diff-f8cb6cb48b51f1241005d2fec679da911c174853c4c5fdf7c99e45f8b9f1380aL75-R76)