### PR TITLE
DTSW-8297-ToF-driver-fixes-for-fixing-inefficiencies-in-data-creation-and-transmission

### DIFF
--- a/packages/tof_driver/package.xml
+++ b/packages/tof_driver/package.xml
@@ -6,6 +6,7 @@
  <maintainer email="akshet.patel@duckietown.com">Akshet Patel</maintainer>
  <license>None</license>
 
+ <depend>builtin_interfaces</depend>
  <depend>duckietown_msgs</depend>
  <depend>rclpy</depend>
  <depend>std_msgs</depend>

--- a/packages/tof_driver/tof_driver/tof_driver_node.py
+++ b/packages/tof_driver/tof_driver/tof_driver_node.py
@@ -4,6 +4,7 @@ import asyncio
 from threading import Thread
 
 import rclpy
+from builtin_interfaces.msg import Time as TimeMsg
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.node import Node as ROS2Node
 from sensor_msgs.msg import Range as ROSRange
@@ -93,7 +94,14 @@ class ToFNode(ROS2Node):
         # create Range message
         tof_msg = ROSRange()
         tof_msg.header = Header()
-        tof_msg.header.stamp = self.get_clock().now().to_msg()
+        # stamp with the driver's read time, not ours: it is the closest we have to when the
+        # chip actually measured. This node's own receive time only tells you when the bridge
+        # got around to forwarding it, which drifts with scheduling and I2C bus contention
+        driver_timestamp = getattr(tof.header, "timestamp", None)
+        if driver_timestamp is not None:
+            tof_msg.header.stamp = self._stamp_from_epoch(driver_timestamp)
+        else:
+            tof_msg.header.stamp = self.get_clock().now().to_msg()
         frame_id = getattr(tof.header, "frame", None)
         if isinstance(frame_id, bytes):
             try:
@@ -115,6 +123,17 @@ class ToFNode(ROS2Node):
         # print(tof_msg)
         self._pub.publish(tof_msg)
         # self.get_logger().info(f"Published range message: {tof_msg}")
+
+    @staticmethod
+    def _stamp_from_epoch(epoch_seconds: float) -> TimeMsg:
+        sec = int(epoch_seconds)
+        nanosec = int(round((epoch_seconds - sec) * 1e9))
+        # rounding a fraction just under a second carries into the next one, and a
+        # nanosec of 1e9 is out of contract even though it fits the field
+        if nanosec >= 1_000_000_000:
+            sec += 1
+            nanosec -= 1_000_000_000
+        return TimeMsg(sec=sec, nanosec=nanosec)
 
     async def worker(self):
         try:

--- a/packages/tof_driver/tof_driver/tof_driver_node.py
+++ b/packages/tof_driver/tof_driver/tof_driver_node.py
@@ -12,10 +12,17 @@ from dt_robot_utils import get_robot_name
 from dtps import context
 from dtps_http import RawData
 from duckietown_messages.sensors.range import Range
+from duckietown_messages.sensors.range_finder import RangeFinder
 from duckietown_messages.utils.exceptions import DataDecodingError
 
-MAX_RANGE = 99  # meters
-OUT_OF_RANGE = 999
+# well outside [min_range, max_range], which is how sensor_msgs/Range says to mark a
+# reading the consumer should discard
+OUT_OF_RANGE = 999.0
+
+# used until the driver's info message arrives. VL53L1X in long distance mode
+DEFAULT_MIN_RANGE = 0.04  # meters
+DEFAULT_MAX_RANGE = 3.6  # meters
+DEFAULT_FOV = 0.471  # radians, 27 degrees
 
 
 class ToFNode(ROS2Node):
@@ -25,6 +32,10 @@ class ToFNode(ROS2Node):
         # arguments
         self.declare_parameter("sensor_name", "front_center")
         self._sensor_name = self.get_parameter("sensor_name").get_parameter_value().string_value
+        # replaced by whatever the driver advertises on its info queue
+        self._min_range: float = DEFAULT_MIN_RANGE
+        self._max_range: float = DEFAULT_MAX_RANGE
+        self._fov: float = DEFAULT_FOV
         # create publisher
         self._pub = self.create_publisher(
             ROSRange,
@@ -32,6 +43,28 @@ class ToFNode(ROS2Node):
             1
         )
         self.get_logger().info(f"Initialized for {self._sensor_name} sensor.")
+
+    async def on_info(self, data: RawData):
+        """Pick up the sensor's real geometry from the driver. Without it the messages go
+        out with an unset fov and minimum, making the standard validity check meaningless.
+        """
+        try:
+            info: RangeFinder = RangeFinder.from_rawdata(data)
+        except DataDecodingError as e:
+            self.get_logger().error(f"Failed to decode the sensor info message: {e.message}")
+            return
+        before = (self._min_range, self._max_range, self._fov)
+        if info.minimum is not None:
+            self._min_range = float(info.minimum)
+        if info.maximum is not None:
+            self._max_range = float(info.maximum)
+        if info.fov is not None:
+            self._fov = float(info.fov)
+        if (self._min_range, self._max_range, self._fov) != before:
+            self.get_logger().info(
+                f"Sensor geometry: fov={self._fov:.3f}rad, "
+                f"range=[{self._min_range}, {self._max_range}]m."
+            )
 
     async def publish(self, data: RawData):
         # print(data)
@@ -49,11 +82,12 @@ class ToFNode(ROS2Node):
         if tof.data is not None and isinstance(tof.data, (float, int)):
             distance = float(tof.data)
         else:
-            self.get_logger().warn(f"Invalid or None data received: {tof.data}")
+            # the driver sends nothing when the chip saw no target, which is ordinary
+            # for a sensor pointed at open space, so this is not a warning
+            self.get_logger().debug("No target in range.")
             distance = OUT_OF_RANGE
 
-        if distance > MAX_RANGE:
-            self.get_logger().warn(f"Distance {distance} is out of valid range, setting to max range {OUT_OF_RANGE}")
+        if distance > self._max_range:
             distance = OUT_OF_RANGE
 
         # create Range message
@@ -71,7 +105,11 @@ class ToFNode(ROS2Node):
         elif not isinstance(frame_id, str):
             frame_id = str(frame_id)
         tof_msg.header.frame_id = frame_id
-        tof_msg.max_range = float(MAX_RANGE)
+        # left unset, radiation_type reads as ULTRASOUND
+        tof_msg.radiation_type = ROSRange.INFRARED
+        tof_msg.field_of_view = float(self._fov)
+        tof_msg.min_range = float(self._min_range)
+        tof_msg.max_range = float(self._max_range)
         tof_msg.range = float(distance)  # Ensure distance is float
         tof_msg.variance = 0.0
         # print(tof_msg)
@@ -82,6 +120,8 @@ class ToFNode(ROS2Node):
         try:
             switchboard = (await context("switchboard")).navigate(self._robot_name)
             self.get_logger().info("Connected to switchboard context.")
+            info = await (switchboard / "sensor" / "time_of_flight" / self._sensor_name / "info").until_ready()
+            await info.subscribe(self.on_info)
             tof = await (switchboard / "sensor" / "time_of_flight" / self._sensor_name / "range").until_ready()
             self.get_logger().info(f"Publishing to topic: sensor/time_of_flight/{self._sensor_name}/range")
             await tof.subscribe(self.publish)


### PR DESCRIPTION
The bridge filled in almost nothing that `sensor_msgs/Range` has room for. `radiation_type`,
`field_of_view`, `min_range` and `variance` were never set, so they read as 0, and `max_range`
was pinned to a fixed guard of 99 metres. A consumer applying the standard
`min_range <= range <= max_range` check got a check that could never reject anything, and the
message claimed to be from an ultrasound transducer when the sensor is an infrared laser.

Everything needed was already being published and nobody was listening. The driver advertises the
real field of view, minimum and maximum on its `info` queue at
`sensor/time_of_flight/<name>/info`. This subscribes to it and fills the fields in. DTPS retains
the last value, so a bridge that starts after the driver still gets it, verified on pdrone24.
Datasheet defaults for the VL53L1X in long distance mode cover the gap before it arrives.

- subscribe to the driver's `info` queue and populate `radiation_type`, `field_of_view`,
  `min_range` and `max_range`
- drop `MAX_RANGE = 99`. With a real maximum in place the out-of-range test finally means
  something, so it uses the sensor's own maximum
- keep the `999.0` sentinel unchanged. It is well outside `[min_range, max_range]`, which is how
  the message contract says to mark a reading the consumer should discard
- drop two log lines that fired on every message. A `None` reading means the chip saw no target,
  which is ordinary for a sensor pointed at open space rather than something to warn about, and
  at 30 Hz it filled the log

Verified on pdrone24, on `/pdrone24/bottom_tof_driver_node/range`: